### PR TITLE
Make code compile position independent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ project(nodec LANGUAGES CXX)
 add_library(${PROJECT_NAME} STATIC
     src/nodec/unicode.cpp
 )
+set_target_properties(${PROJECT_NAME} PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_17)
 


### PR DESCRIPTION
On linux the `-fPIC` flag is needed if nodec is compiled as a static library and linked into a shared object (.so)